### PR TITLE
Update pipeline def to use go 1.18.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,11 +20,11 @@ kupid:
                 build: ~
     steps:
       check:
-        image: 'golang:1.13.11'
+        image: 'golang:1.18.2'
       test:
-        image: 'golang:1.13.11'
+        image: 'golang:1.18.2'
       build:
-        image: 'golang:1.13.11'
+        image: 'golang:1.18.2'
         output_dir: 'binary'
 
   jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates pipeline definitions to use `go 1.18.2`.
This is required as currently updating the Kupid to 1.18.2 fails to build due to pipeline definitions still pointing to `go 1.13.11`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
"NONE"
```
