### PR TITLE
Update controller-gen handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ IMG ?= $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
+CONTROLLER_GEN_REQVERSION := v0.6.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -107,7 +108,17 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_REQVERSION) ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	}
+CONTROLLER_GEN=$(GOBIN)/controller-gen
+else ifneq (Version: $(CONTROLLER_GEN_REQVERSION), $(shell controller-gen --version))
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_REQVERSION) ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
**What this PR does / why we need it**:
Makefile used in this project  has certain gaps which creeps in when generating CRDs via `make manifests` namely - 
* It doesn't allow configuring a required `controller-gen` version 
* It still uses `go get` instead of `go install` while installing `controller-gen`
* It only checks if the `controller-gen` exists and doesn't check if the version installed is what is specified as the required version for generation. 

This PR fixes this by enhancing the Makefile to handle these limitations or gaps. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bug operator
A bug in Makefile handling of `controller-gen` version and its installation is now fixed'
```
