### PR TITLE
fixes the issue where the mutation log does not get printed the first…

### DIFF
--- a/pkg/webhook/injector.go
+++ b/pkg/webhook/injector.go
@@ -233,6 +233,7 @@ func mergeUniquePreferredSchedulingTerms(s []corev1.PreferredSchedulingTerm, mut
 
 func mergeUniqueNodeSelectorTerms(policyNSTs, podNSTs []corev1.NodeSelectorTerm, log logr.Logger) []corev1.NodeSelectorTerm {
 	if podNSTs == nil || len(podNSTs) == 0 {
+		printDeltaUniqueNodeSelectorTerms(podNSTs, policyNSTs, log)
 		return policyNSTs
 	}
 	if policyNSTs == nil || len(policyNSTs) == 0 {
@@ -249,6 +250,10 @@ func mergeUniqueNodeSelectorTerms(policyNSTs, podNSTs []corev1.NodeSelectorTerm,
 }
 
 func printDeltaUniqueNodeSelectorTerms(podNSTs, updatedNSTs []corev1.NodeSelectorTerm, log logr.Logger) {
+	if (podNSTs == nil || len(podNSTs) == 0) && (updatedNSTs != nil && len(updatedNSTs) > 0) {
+		log.Info("Mutations made to RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms", "mutated NSTs", updatedNSTs)
+	}
+
 	var contains = func(podNSTs []corev1.NodeSelectorTerm, updatedNST corev1.NodeSelectorTerm) bool {
 		for _, podNST := range podNSTs {
 			if reflect.DeepEqual(podNST, updatedNST) {


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of https://github.com/gardener/kupid/pull/59 we added logic to take a cartesian product of NSRs. Along with that change we also added an ability to compute the delta change and print it to the logs for better diagnostics. However there was a gap left where the first time a change is done to a k8s resource (e.g. sts) where there are no existing node affinity policies defined and kupid injects the policies as defined in the clusterpodschedulingpolicies then it does not print that mutation in the logs.

**Which issue(s) this PR fixes**:
Fixes #60 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Will also log the first mutation done to NodeAffinity policies done to a resource where none existed.
```
