### PR TITLE
Add ownerReference to webhooks

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func doRegisterWebhooks(mgr manager.Manager, certDir, namespace string, timeoutS
 		newValidatingWebhookConfig,
 		newMutatingWebhookConfig,
 	} {
-		obj, mutateFn := f(clientConfig, timeoutSeconds, webhookFailurePolicy)
+		obj, mutateFn := f(clientConfig, timeoutSeconds, webhookFailurePolicy, namespace)
 		if _, err := controllerutil.CreateOrUpdate(ctx, k8sClient, obj, mutateFn); err != nil {
 			return err
 		}
@@ -251,10 +251,10 @@ func buildRuleWithOperations(gv schema.GroupVersion, resources []string, operati
 	}
 }
 
-type webhookConfigGeneratorFn func(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType) (client.Object, controllerutil.MutateFn)
+type webhookConfigGeneratorFn func(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn)
 
 // func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32) (client.Object, controllerutil.MutateFn) {
-func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType) (client.Object, controllerutil.MutateFn) {
+func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn) {
 	var (
 		exact = admissionregistrationv1.Exact
 		none  = admissionregistrationv1.SideEffectClassNone
@@ -263,6 +263,9 @@ func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClie
 	obj := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookFullName,
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace},
+			},
 		},
 	}
 
@@ -294,7 +297,7 @@ func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClie
 	}
 }
 
-func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType) (client.Object, controllerutil.MutateFn) {
+func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn) {
 	var (
 		equivalent = admissionregistrationv1.Equivalent
 		none       = admissionregistrationv1.SideEffectClassNone
@@ -304,6 +307,9 @@ func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClient
 	obj := &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookFullName,
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace},
+			},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	uberzap "go.uber.org/zap"
@@ -215,11 +216,17 @@ func doRegisterWebhooks(mgr manager.Manager, certDir, namespace string, timeoutS
 
 	setupLog.Info("Registering webhooks if necessary.")
 
+	namespaceObj := &corev1.Namespace{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: namespace}, namespaceObj); err != nil {
+		return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+	}
+	namespaceUID := namespaceObj.UID
+
 	for _, f := range []webhookConfigGeneratorFn{
 		newValidatingWebhookConfig,
 		newMutatingWebhookConfig,
 	} {
-		obj, mutateFn := f(clientConfig, timeoutSeconds, webhookFailurePolicy, namespace)
+		obj, mutateFn := f(clientConfig, timeoutSeconds, webhookFailurePolicy, namespace, namespaceUID)
 		if _, err := controllerutil.CreateOrUpdate(ctx, k8sClient, obj, mutateFn); err != nil {
 			return err
 		}
@@ -251,10 +258,9 @@ func buildRuleWithOperations(gv schema.GroupVersion, resources []string, operati
 	}
 }
 
-type webhookConfigGeneratorFn func(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn)
+type webhookConfigGeneratorFn func(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string, namespaceUID types.UID) (client.Object, controllerutil.MutateFn)
 
-// func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32) (client.Object, controllerutil.MutateFn) {
-func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn) {
+func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string, namespaceUID types.UID) (client.Object, controllerutil.MutateFn) {
 	var (
 		exact = admissionregistrationv1.Exact
 		none  = admissionregistrationv1.SideEffectClassNone
@@ -264,7 +270,7 @@ func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClie
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookFullName,
 			OwnerReferences: []metav1.OwnerReference{
-				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace},
+				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace, UID: namespaceUID},
 			},
 		},
 	}
@@ -297,7 +303,7 @@ func newValidatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClie
 	}
 }
 
-func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string) (client.Object, controllerutil.MutateFn) {
+func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClientConfig, timeoutSeconds int32, webhookFailurePolicy admissionregistrationv1.FailurePolicyType, extensionNamespace string, namespaceUID types.UID) (client.Object, controllerutil.MutateFn) {
 	var (
 		equivalent = admissionregistrationv1.Equivalent
 		none       = admissionregistrationv1.SideEffectClassNone
@@ -308,7 +314,7 @@ func newMutatingWebhookConfig(clientConfig admissionregistrationv1.WebhookClient
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookFullName,
 			OwnerReferences: []metav1.OwnerReference{
-				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace},
+				{APIVersion: "v1", Kind: "Namespace", Name: extensionNamespace, UID: namespaceUID},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an `ownerReference` to the webhook configurations created by the extension. As an owner, the extension's namespace is referenced, such that when the extension is entirely removed from a Cluster (and the namespace gets removed), the webhook configurations get removed as well.

Hat tip to @vpnachev for the suggestion!

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Make sure WebhookConfigurations created by the extension get removed when the extension namespace is deleted by adding an ownerReference.
```
