### PR TITLE
migrate cc-utils actions/workflows from @master to @v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
     with:
       mode: ${{ inputs.mode }}
     permissions:
@@ -28,7 +28,7 @@ jobs:
       packages: write
       id-token: write
     secrets: inherit
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1
     strategy:
       matrix:
         args:
@@ -53,7 +53,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@v1
     strategy:
       matrix:
         args:
@@ -73,7 +73,7 @@ jobs:
       ocm-mappings: ${{ toJSON(matrix.args.ocm-mappings) }}
 
   sast-lint:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1
     permissions:
       contents: read
     with:
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
@@ -98,7 +98,7 @@ jobs:
 
           tar czf /tmp/blobs.d/test-log.tar.gz -C /tmp/blobs.d test-log.txt
       - name: add-reports-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@master
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@master
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
     needs:
       - build
     secrets: inherit


### PR DESCRIPTION
Switch references to [cc-utils](https://github.com/gardener/cc-utils)
actions and reusable workflows from `@master` to `@v1`.

## Motivation

`v1` is the intended stable branch for downstream users. All internal cross-references
are pinned by commit digest, ensuring a consistent, self-contained snapshot. Coverage
(e.g. pre-qualification) will increase over time.

`master` remains the development branch and continues to work, but is not intended for
downstream consumption.

See the [Reuse and Branching Model](https://gardener.github.io/cc-utils) for details.
